### PR TITLE
Add code modification to use xla

### DIFF
--- a/transact_code/test_run_transact.py
+++ b/transact_code/test_run_transact.py
@@ -3,7 +3,7 @@ from transact import TransAct
 from transact_config import TransActConfig
 
 
-def test_run_transact(use_xla=False):
+def test_run_transact(device='cpu'):
     action_vocab = list(range(0, 20))
     full_seq_len = 100
     test_batch_size = 8
@@ -12,11 +12,11 @@ def test_run_transact(use_xla=False):
     time_window_ms = 1000 * 60 * 60 * 1  # 1 hr
     latest_n_emb = 10
 
-    if use_xla:
+    if device == 'xla':
         import torch_xla
-        device = 'xla'
-    else:
-        device = 'cpu'
+    elif device == 'jax':
+        import torchax
+        torchax.enable_globally()
 
 
 

--- a/transact_code/test_run_transact.py
+++ b/transact_code/test_run_transact.py
@@ -3,7 +3,7 @@ from transact import TransAct
 from transact_config import TransActConfig
 
 
-def test_run_transact():
+def test_run_transact(use_xla=False):
     action_vocab = list(range(0, 20))
     full_seq_len = 100
     test_batch_size = 8
@@ -12,11 +12,19 @@ def test_run_transact():
     time_window_ms = 1000 * 60 * 60 * 1  # 1 hr
     latest_n_emb = 10
 
-    action_type_seq = torch.randint(0, 20, (test_batch_size, full_seq_len))
-    item_embedding_seq = torch.rand(test_batch_size, full_seq_len, item_emb_dim)
-    action_time_seq = torch.randint(0, 20, (test_batch_size, full_seq_len))
-    request_time = torch.randint(500, 1000, (test_batch_size,))
-    item_embedding = torch.rand(test_batch_size, item_emb_dim)
+    if use_xla:
+        import torch_xla
+        device = 'xla'
+    else:
+        device = 'cpu'
+
+
+
+    action_type_seq = torch.randint(0, 20, (test_batch_size, full_seq_len), device=device)
+    item_embedding_seq = torch.rand(test_batch_size, full_seq_len, item_emb_dim, device=device)
+    action_time_seq = torch.randint(0, 20, (test_batch_size, full_seq_len), device=device)
+    request_time = torch.randint(500, 1000, (test_batch_size,), device=device)
+    item_embedding = torch.rand(test_batch_size, item_emb_dim, device=device)
     input_features = (
         action_type_seq,
         item_embedding_seq,
@@ -35,7 +43,7 @@ def test_run_transact():
         latest_n_emb=latest_n_emb,
     )
 
-    transact_module = TransAct(transact_config)
+    transact_module = TransAct(transact_config).to(device)
 
     print("Test forward pass")
     output = transact_module(*input_features)
@@ -43,4 +51,6 @@ def test_run_transact():
     print("Test succeeded")
 
 
-test_run_transact()
+if __name__ == '__main__':
+    import fire
+    fire.Fire(test_run_transact)


### PR DESCRIPTION
WARNING:root:Defaulting to PJRT_DEVICE=CPU
Initializing TransAct...
Test forward pass
tensor([[-0.9918, -0.8209,  0.1392,  ..., -0.3904, -0.1581, -0.0905],
        [-0.2683, -0.3503,  0.6804,  ...,  0.7961,  0.1153,  0.8060],
        [-0.8711, -0.1360,  0.4706,  ..., -0.3300, -0.1462,  0.6417],
        ...,
        [-1.2410, -0.3137, -0.0425,  ..., -2.0449,  1.5555,  0.1358],
        [-0.4742, -0.0498,  0.9682,  ...,  0.1295,  0.0319,  0.5132],
        [-0.7454, -0.5072,  0.3134,  ...,  0.4772,  0.9824, -0.5429]],
       device='xla:0', grad_fn=<CatBackward0>)
Test succeeded